### PR TITLE
add static variable to the context of the script

### DIFF
--- a/models.py
+++ b/models.py
@@ -127,6 +127,7 @@ class Script(JavaBean):
         self._compiled_content = content
         self._compilation_error = ''
         self._is_compiled = False
+        self._statics = {}
 
     def to_dict(self):
         fields = ['title', 'enabled', 'content']
@@ -152,7 +153,8 @@ class Script(JavaBean):
                         'toolFlag': toolFlag,
                         'messageIsRequest': messageIsRequest,
                         'messageInfo': messageInfo,
-                        'macroItems': macroItems
+                        'macroItems': macroItems,
+                        'statics': self._statics
                         }
 
             oldstderr = sys.stderr


### PR DESCRIPTION
This PR enables a user to add key-value pairs for later use.
In my case, I had to increment one of the parameters in every request.
To achieve this goal,  I wrote a PoC script:

```python
if messageIsRequest:
    statics['counter']=statics.get('counter',0)+1
    print(statics['counter'])
```

Note that the variable `statics` in the script is newly defined by this PR.

After I loaded the script to Python Scripter and sent two requests, the UI shows:

```
1
2
```

As you see, `statics['counter']`  worked as a counter.
 
I think this can be done by using another extension, but this PR can make it simpler and Python Scripter more flexible.